### PR TITLE
feat: repeat till EOF when loading pickle

### DIFF
--- a/pyscripts/read_files.py
+++ b/pyscripts/read_files.py
@@ -70,9 +70,16 @@ elif file_type == FileType.PICKLE.value:
     # Solve pickle files .pkl
     try:
         import pickle
+        i = 0
         with open(file_path, "rb") as f:
-            content = pickle.load(f)
-        print(content)
+            while True:
+                try:
+                    content = pickle.load(f)
+                    print(f'Item {i}:')
+                    print(content)
+                    i += 1
+                except EOFError:
+                    break
     except UnicodeDecodeError:
         with open(file_path, "rb") as f:
             content = pickle.load(f, encoding="latin1")


### PR DESCRIPTION
This is useful when multiple objects were written to the same file like
```
pickle.dump(obj1, f)
pickle.dump(obj2, f)
```