### PR TITLE
Use CPU to load torch files

### DIFF
--- a/pyscripts/read_files.py
+++ b/pyscripts/read_files.py
@@ -116,7 +116,7 @@ elif file_type == FileType.PYTORCH.value:
     # Solve pytorch files .pth
     try:
         import torch
-        content = torch.load(file_path)
+        content = torch.load(file_path, map_location='cpu')
         print(content)
     except Exception as e:
         print(e)


### PR DESCRIPTION
This may fix some bugs since without an env like conda, torch usually does not install correctly.

`Attempting to deserialize object on a CUDA device but torch.cuda.is_available() is False. If you are running on a CPU-only machine, please use torch.load with map_location=torch.device('cpu') to map your storages to the CPU.`