### PR TITLE
Adding commas as the separator between per elements makes it easy to …

### DIFF
--- a/pyscripts/read_files.py
+++ b/pyscripts/read_files.py
@@ -70,7 +70,8 @@ def print_ndarray(array):
             print("]")
     else:
         print("<b><i>shape: {}</i></b>".format(array.shape))
-        print(array)
+        # repr(array) will outputs "array([e, e, ...])", we cut the head "array(" and tail ")", then replace redundant 6 spaces per line
+        print(repr(array)[6:-1].replace(" " * 6, ""))
 
 if file_type == FileType.NUMPY.value:
     # Solve numpy files .npy or .npz

--- a/src/pydataPreview.ts
+++ b/src/pydataPreview.ts
@@ -156,7 +156,7 @@ export class PyDataPreview extends Disposable {
           if (r[i].startsWith('<img')) {
             continue;
           }
-          r[i] = r[i].replaceAll(" ", "&ensp;");
+          r[i] = r[i].replaceAll(" ", "&nbsp;");
         }
         content = r.join('<br>');
         const head = `<!DOCTYPE html>


### PR DESCRIPTION
…copy from numpy outputs.

Related to issue #28
Testing logs
```zsh
❯ tsc
❯ node out/test/runTest.js
Found existing install in /Users/vela/WorkDir/vscode-pydata-viewer/.vscode-test/vscode-darwin-arm64-1.89.1. Skipping download
2024-05-24 19:42:49.982 Electron[26936:1092594] WARNING: Secure coding is automatically enabled for restorable state! However, not on all supported macOS versions of this application. Opt-in to secure coding explicitly by implementing NSApplicationDelegate.applicationSupportsSecureRestorableState:.
[main 2024-05-24T11:42:50.182Z] update#setState disabled
[main 2024-05-24T11:42:50.184Z] update#ctor - updates are disabled by the environment
2024-05-24 19:42:50.595 Code Helper (Renderer)[26941:1092707] CoreText note: Client requested name ".NewYork-Regular", it will get TimesNewRomanPSMT rather than the intended font. All system UI font access should be through proper APIs such as CTFontCreateUIFontForLanguage() or +[NSFont systemFontOfSize:].
2024-05-24 19:42:50.595 Code Helper (Renderer)[26941:1092707] CoreText note: Set a breakpoint on CTFontLogSystemFontNameRequest to debug.
Loading development extension at /Users/vela/WorkDir/vscode-pydata-viewer
Started local extension host with pid 26980.

  Extension Test Suite
    ✔ Sample test
  1 passing (2ms)
[main 2024-05-24T11:42:51.319Z] Extension host with pid 26980 exited with code: 0, signal: unknown.
Exit code:   0
Done
```