### PR TITLE
feat: follow Python extension interpreter (Python: Select Interpreter)

### DIFF
--- a/CONFIG_GUIDE.md
+++ b/CONFIG_GUIDE.md
@@ -3,14 +3,17 @@
 ## Quick Setup / 快速配置
 
 ### 1. Basic Settings / 基本设置
+
 Open VS Code Settings (`Cmd+,`) and search for "pydata viewer" to configure:
 
 打开 VS Code 设置 (`Cmd+,`)，搜索 "pydata viewer"，配置：
 
 - **Python Path**: Set to your Python interpreter path / 设置为你的 Python 解释器路径
+- **Use Python Extension Interpreter**: Automatically follow `ms-python.python` active interpreter when Python Path is `default` / 当 Python Path 为 `default` 时自动跟随 `ms-python.python` 的活动解释器
 - **Script Path**: Set to custom script path (optional) / 设置为自定义脚本路径（可选）
 
 ### 2. Using uv Environment / 使用 uv 环境
+
 If you use uv to manage your Python environment:
 
 如果你使用 uv 管理 Python 环境：
@@ -27,18 +30,21 @@ Set the output path as Python Path.
 ### 3. Handling Local Imports / 处理本地导入
 
 #### Method 1: Workspace Configuration / 方法 1: 工作区配置
+
 Create `.vscode/settings.json` in your project root:
 
 在项目根目录创建 `.vscode/settings.json`：
 
 ```json
 {
-  "vscode-pydata-viewer.pythonPath": "/path/to/your/python",
+   "vscode-pydata-viewer.pythonPath": "default",
+   "vscode-pydata-viewer.usePythonExtensionInterpreter": true,
   "vscode-pydata-viewer.scriptPath": "${workspaceFolder}/simple_processor.py"
 }
 ```
 
 #### Method 2: Custom Script / 方法 2: 自定义脚本
+
 Create a processing script:
 
 创建一个处理脚本：
@@ -72,11 +78,13 @@ if __name__ == "__main__":
 ## Testing Steps / 测试步骤
 
 1. **Create test files / 创建测试文件**：
+
    ```bash
    uv run python test_local_imports.py create
    ```
 
 2. **Test custom script / 测试自定义脚本**：
+
    ```bash
    uv run python simple_processor.py 1 test_output/test_model.pkl
    ```
@@ -90,6 +98,9 @@ if __name__ == "__main__":
    - You should see formatted output / 应该能看到格式化的输出
 
 ## Common Issues / 常见问题
+
+**Q: Why doesn't interpreter follow Python: Select Interpreter? / 为什么没有跟随 Python: Select Interpreter？**
+A: Ensure `ms-python.python` is installed, set `vscode-pydata-viewer.pythonPath` to `default`, and enable `vscode-pydata-viewer.usePythonExtensionInterpreter`. / 请确认已安装 `ms-python.python`，并将 `vscode-pydata-viewer.pythonPath` 设为 `default`，`vscode-pydata-viewer.usePythonExtensionInterpreter` 设为 `true`。
 
 **Q: Getting "No module named" error? / 出现 "No module named" 错误？**
 A: Add `sys.path.insert(0, str(Path(__file__).parent))` to your custom script / 在自定义脚本中添加 `sys.path.insert(0, str(Path(__file__).parent))`

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ Display Python data files in VSCode.
 
 ## Quick Start
 
-1. Install the extension from VS Code marketplace
-2. Open any supported data file in VS Code
-3. The file will automatically display with formatted content
+1. Install the extension from VS Code marketplace.
+2. Open any supported data file in VS Code.
+3. The file will automatically display with formatted content.
 
 ## Requirements
 
@@ -30,17 +30,29 @@ Display Python data files in VSCode.
 
 ### Extension Settings
 
-- `vscode-pydata-viewer.pythonPath`: Path to Python interpreter (default: `"default"`)
-- `vscode-pydata-viewer.scriptPath`: Path to custom processing script (default: `"default"`)
+- `vscode-pydata-viewer.pythonPath`: Path to Python interpreter (default: `"default"`).
+- `vscode-pydata-viewer.usePythonExtensionInterpreter`: Use active interpreter from `ms-python.python` when `pythonPath="default"` (default: `true`).
+- `vscode-pydata-viewer.scriptPath`: Path to custom processing script (default: `"default"`).
+
+### Interpreter Resolution Priority
+
+When opening a data file, interpreter selection follows:
+
+1. `vscode-pydata-viewer.pythonPath` if not `"default"`
+2. Active interpreter from Python extension (`ms-python.python`) if available and enabled
+3. Fallback to system/default Python used by `python-shell`
+
+> To use automatic follow mode, install the Python extension (`ms-python.python`).
 
 ### Python Path Setup
 
-1. Open VS Code Settings (`Cmd+,` or `Ctrl+,`)
-2. Search for "pydata viewer"
-3. Set **Python Path**:
-   - **System Python**: Leave as `"default"`
-   - **Virtual Environment**: `/path/to/venv/bin/python`
-   - **Conda Environment**: `/path/to/conda/envs/myenv/bin/python`
+1. Open VS Code Settings (`Cmd+,` or `Ctrl+,`).
+2. Search for `pydata viewer`.
+3. Set one of these **Python Path** options:
+   - **Auto follow interpreter**: Leave as `"default"` and keep `usePythonExtensionInterpreter=true`.
+   - **System Python fallback**: Leave as `"default"` without Python extension.
+   - **Virtual Environment**: `/path/to/venv/bin/python`.
+   - **Conda Environment**: `/path/to/conda/envs/myenv/bin/python`.
 
 ## Handling Local Imports
 
@@ -70,12 +82,13 @@ def process_pickle_file(file_path):
 if __name__ == "__main__":
     file_type = int(sys.argv[1])
     file_path = sys.argv[2]
-    
+
     if file_type == 1:  # Pickle file
         process_pickle_file(file_path)
 ```
 
 Then set the script path in VS Code settings:
+
 ```json
 {
   "vscode-pydata-viewer.scriptPath": "/path/to/your/custom_script.py"
@@ -106,21 +119,31 @@ For project-specific configuration, create `.vscode/settings.json`:
 ## Common Issues
 
 **"No module named 'your_module'" Error**
-- Use a custom script with proper imports
-- Set Python path to your project environment
-- Ensure your virtual environment contains required dependencies
+
+- Use a custom script with proper imports.
+- Set Python path to your project environment.
+- Ensure your virtual environment contains required dependencies.
 
 **"Python not found" Error**
-- Check Python installation
-- Set full path to Python executable in settings
-- Restart VS Code after changing settings
+
+- Check Python installation.
+- Set full path to Python executable in settings.
+- Restart VS Code after changing settings.
+
+**Interpreter does not follow `Python: Select Interpreter`**
+
+- Ensure `ms-python.python` is installed and enabled.
+- Set `vscode-pydata-viewer.pythonPath` to `"default"`.
+- Keep `vscode-pydata-viewer.usePythonExtensionInterpreter` as `true`.
 
 ## Examples
 
 ### Basic Usage
+
 Simply open any `.npy`, `.pkl`, or `.pth` file in VS Code.
 
 ### Custom Objects
+
 ```python
 import pickle
 
@@ -140,5 +163,3 @@ Please refer to [CHANGELOG.md](./CHANGELOG.md).
 ## Related Extensions
 
 If you don't have Python available but need to view numpy files, try [vscode-numpy-viewer](https://github.com/haochengxia/vscode-numpy-viewer).
-
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,14 @@
 {
 	"name": "vscode-pydata-viewer",
-	"version": "0.0.14",
+	"version": "0.0.15",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "vscode-pydata-viewer",
-			"version": "0.0.14",
+			"version": "0.0.15",
 			"dependencies": {
+				"@vscode/python-extension": "^1.0.6",
 				"python-shell": "^5.0.0"
 			},
 			"devDependencies": {
@@ -449,6 +450,7 @@
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
 			"integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "5.62.0",
 				"@typescript-eslint/types": "5.62.0",
@@ -617,6 +619,16 @@
 			"resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
 			"integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
 			"dev": true
+		},
+		"node_modules/@vscode/python-extension": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/@vscode/python-extension/-/python-extension-1.0.6.tgz",
+			"integrity": "sha512-q7KYf+mymM67G0yS6xfhczFwu2teBi5oXHVdNgtCsYhErdSOkwMPtE291SqQahrjTcgKxn7O56i1qb1EQR6o4w==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=22.17.0",
+				"vscode": "^1.93.0"
+			}
 		},
 		"node_modules/@vscode/test-electron": {
 			"version": "2.5.2",
@@ -836,6 +848,7 @@
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
 			"dev": true,
+			"peer": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1809,6 +1822,7 @@
 			"integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
 			"deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
 			"dev": true,
+			"peer": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
@@ -4715,6 +4729,7 @@
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
 			"integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
 			"dev": true,
+			"peer": true,
 			"bin": {
 				"tsc": "bin/tsc",
 				"tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -62,7 +62,12 @@
 					"vscode-pydata-viewer.pythonPath": {
 						"type": "string",
 						"default": "default",
-						"description": "The absolute path of python interpreter. `default` means no custom interpreter."
+						"description": "The absolute path of Python interpreter. `default` means using the active interpreter from Python extension when available, then falling back to system default."
+					},
+					"vscode-pydata-viewer.usePythonExtensionInterpreter": {
+						"type": "boolean",
+						"default": true,
+						"description": "When pythonPath is `default`, use the active interpreter selected by ms-python.python if available."
 					},
 					"vscode-pydata-viewer.scriptPath": {
 						"type": "string",
@@ -98,6 +103,7 @@
 		"test": "node --no-deprecation ./out/test/runTest.js"
 	},
 	"dependencies": {
+		"@vscode/python-extension": "^1.0.6",
 		"python-shell": "^5.0.0"
 	},
 	"devDependencies": {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,7 @@
 // Import the module and reference it with the alias vscode in your code below
 import * as vscode from 'vscode';
 import { PyDataCustomProvider } from './pydataProvider';
+import { PythonInterpreterService } from './pythonInterpreter';
 
 // this method is called when your extension is activated
 // your extension is activated the very first time the command is executed
@@ -11,8 +12,17 @@ export function activate(context: vscode.ExtensionContext) {
 	// This line of code will only be executed once when your extension is activated
 	console.log('Congratulations, your extension "vscode-pydata-viewer" is now active!');
 
+	const interpreterService = new PythonInterpreterService();
+	context.subscriptions.push(interpreterService);
+	void interpreterService.initialize();
+
 	const extensionRoot = vscode.Uri.file(context.extensionPath);
-	const provider = new PyDataCustomProvider(context, extensionRoot);
+	const provider = new PyDataCustomProvider(context, extensionRoot, interpreterService);
+	context.subscriptions.push(
+		interpreterService.onDidChangeInterpreter((event) => {
+			provider.reloadAllPreviews(event.resource);
+		})
+	);
 	context.subscriptions.push(
 		vscode.window.registerCustomEditorProvider(
 			PyDataCustomProvider.viewType,

--- a/src/pydataPreview.ts
+++ b/src/pydataPreview.ts
@@ -1,8 +1,11 @@
 import * as vscode from 'vscode';
+import * as fs from 'fs';
 
 import { Disposable } from './disposable';
 import { getOption, getPyScriptsPath, OSUtils } from './utils';
 import { Options, PythonShell } from 'python-shell';
+import { PythonInterpreterService } from './pythonInterpreter';
+import { PythonPathResolutionResult, resolvePythonPathPriority } from './pythonPathResolution';
 
 type PreviewState = 'Disposed' | 'Visible' | 'Active';
 
@@ -17,12 +20,18 @@ enum FileType {
 export class PyDataPreview extends Disposable {
   private _previewState: PreviewState = 'Visible';
   private _isFullMode: boolean = false;
+  private _loadRequestId: number = 0;
+
+  public get resourceUri(): vscode.Uri {
+    return this.resource;
+  }
 
   constructor(
     private readonly context: vscode.ExtensionContext,
     private readonly extensionRoot: vscode.Uri,
     private readonly resource: vscode.Uri,
-    private readonly webviewEditor: vscode.WebviewPanel
+    private readonly webviewEditor: vscode.WebviewPanel,
+    private readonly interpreterService: PythonInterpreterService
   ) {
     super();
     const resourceRoot = resource.with({
@@ -80,7 +89,7 @@ export class PyDataPreview extends Disposable {
       })
     );
 
-    this.getWebviewContents(this.resource.path);
+    void this.getWebviewContents(this.resource.path);
     this.update();
   }
 
@@ -102,7 +111,9 @@ export class PyDataPreview extends Disposable {
     this._previewState = 'Visible';
   }
 
-  public getWebviewContents(resourcePath: string) {
+  public async getWebviewContents(resourcePath: string): Promise<void> {
+    const requestId = ++this._loadRequestId;
+
     var path = resourcePath;
     switch (OSUtils.isWindows()) {
       case true:
@@ -123,37 +134,27 @@ export class PyDataPreview extends Disposable {
 
     // Call python
     const workspace = vscode.workspace.getWorkspaceFolder(vscode.Uri.file(resourcePath));
+    const workspacePath = workspace ? workspace.uri.fsPath : '';
     console.log('starting python....');
-    var pythonPath = PythonShell.defaultPythonPath;
-    console.log('default python path', pythonPath);
-    const customPythonPath = getOption("vscode-pydata-viewer.pythonPath") as string;
-    if (customPythonPath !== "default") {
-      pythonPath = customPythonPath.replace('${workspaceFolder}', workspace ? workspace.uri.fsPath : "");
-      console.log("[+] custom python path:", pythonPath);
-      
-      // Check if custom python path exists
-      try {
-        const fs = require('fs');
-        if (!fs.existsSync(pythonPath)) {
-          console.error('[ERROR] Custom Python path does not exist:', pythonPath);
-          const errorMsg = `<span style='color:red'>Error: Custom Python path does not exist: ${pythonPath}<br><br>Please check your settings: vscode-pydata-viewer.pythonPath</span>`;
-          const head = `<!DOCTYPE html>
-          <html dir="ltr" mozdisallowselectionprint>
-          <head>
-          <meta charset="utf-8">
-          </head>`;
-          const tail = ['</html>'].join('\n');
-          const output = head + `<body>              
-          <div id="x" style='font-family: Menlo, Consolas, "Ubuntu Mono",
-          "Roboto Mono", "DejaVu Sans Mono",
-          monospace'>` + errorMsg + `</div></body>` + tail;
-          this.webviewEditor.webview.html = output;
-          this.update();
-          return;
-        }
-      } catch (err) {
-        console.error('[ERROR] Failed to check Python path:', err);
-      }
+
+    const pythonResolution = await this.resolvePythonPath(this.resource, workspacePath);
+    if (!pythonResolution.path) {
+      this.renderSimpleMessage(
+        `Error: Unable to resolve Python interpreter.<br><br>${pythonResolution.hint}`,
+        'red'
+      );
+      return;
+    }
+
+    const pythonPath = pythonResolution.path;
+    console.log(`[PyData Viewer] Using python (${pythonResolution.source}):`, pythonPath);
+
+    if (this.shouldValidatePathExists(pythonPath) && !this.existsPath(pythonPath)) {
+      this.renderSimpleMessage(
+        `Error: Python path does not exist: ${pythonPath}<br><br>${pythonResolution.hint}`,
+        'red'
+      );
+      return;
     }
 
     let options: Options = {
@@ -172,12 +173,15 @@ export class PyDataPreview extends Disposable {
     if (scriptPath === "default") {
       scriptPath = getPyScriptsPath("read_files.py", this.context);
     } else {
-      scriptPath = scriptPath.replace('${workspaceFolder}', workspace? workspace.uri.fsPath : "");
+      scriptPath = scriptPath.replace('${workspaceFolder}', workspacePath);
     }
 
     console.log("current deployed script", scriptPath);
     console.log("Python options:", JSON.stringify(options));
     PythonShell.run(scriptPath, options).then(results => {
+        if (!this.shouldApplyResult(requestId)) {
+          return;
+        }
         // results is an array consisting of messages collected during execution
         console.log('results: %j', results);
         console.log('results length:', results?.length);
@@ -195,8 +199,7 @@ export class PyDataPreview extends Disposable {
           <div id="x" style='font-family: Menlo, Consolas, "Ubuntu Mono",
           "Roboto Mono", "DejaVu Sans Mono",
           monospace'>` + errorMsg + `</div></body>` + tail;
-          handle.webviewEditor.webview.html = output;
-          handle.update();
+          handle.safeApplyWebviewHtml(requestId, output);
           return;
         }
         
@@ -220,9 +223,11 @@ export class PyDataPreview extends Disposable {
         "Roboto Mono", "DejaVu Sans Mono",
         monospace'>` + content + `</div></body>` + tail;
         console.log(output);
-        handle.webviewEditor.webview.html = output;
-        handle.update();
+        handle.safeApplyWebviewHtml(requestId, output);
     }).catch(err => {
+        if (!this.shouldApplyResult(requestId)) {
+          return;
+        }
         console.log('Python error:', err);
         console.log('Error type:', typeof err);
         console.log('Error stack:', err?.stack);
@@ -233,12 +238,12 @@ export class PyDataPreview extends Disposable {
         </head>`;
         const tail = ['</html>'].join('\n');
         const errorDetails = err?.message || err?.toString() || 'Unknown error';
+        const interpreterPath = options.pythonPath ?? '<unknown>';
         const output = head + `<body>              
         <div id="x" style='color: red; font-family: Menlo, Consolas, "Ubuntu Mono",
         "Roboto Mono", "DejaVu Sans Mono",
-        monospace'>Error: ` + errorDetails + `</div></body>` + tail;
-        handle.webviewEditor.webview.html = output;
-        handle.update();
+        monospace'>Error: ` + errorDetails + `<br><br>Interpreter: ` + interpreterPath + `</div></body>` + tail;
+        handle.safeApplyWebviewHtml(requestId, output);
     });
 
     // Replace , with ,\n for reading
@@ -258,7 +263,73 @@ export class PyDataPreview extends Disposable {
 
   public toggleTruncation(): void {
     this._isFullMode = !this._isFullMode;
-    this.getWebviewContents(this.resource.path);
+    void this.getWebviewContents(this.resource.path);
+  }
+
+  public refreshFromInterpreterChange(): void {
+    void this.getWebviewContents(this.resource.path);
+  }
+
+  private shouldApplyResult(requestId: number): boolean {
+    return this._previewState !== 'Disposed' && requestId === this._loadRequestId;
+  }
+
+  private safeApplyWebviewHtml(requestId: number, html: string): void {
+    if (!this.shouldApplyResult(requestId)) {
+      return;
+    }
+    this.webviewEditor.webview.html = html;
+    this.update();
+  }
+
+  private existsPath(path: string): boolean {
+    try {
+      return fs.existsSync(path);
+    } catch (error) {
+      console.error('[PyData Viewer] Failed to check path existence:', error);
+      return false;
+    }
+  }
+
+  private shouldValidatePathExists(path: string): boolean {
+    // If user provides a command name like "python"/"python3", let python-shell resolve it via PATH.
+    // Only validate existence when this looks like an explicit file path.
+    return path.includes('/') || path.includes('\\') || path.includes(':');
+  }
+
+  private renderSimpleMessage(messageHtml: string, color: string): void {
+    const head = `<!DOCTYPE html>
+        <html dir="ltr" mozdisallowselectionprint>
+        <head>
+        <meta charset="utf-8">
+        </head>`;
+    const tail = ['</html>'].join('\n');
+    const output = head + `<body>
+        <div id="x" style='color: ${color}; font-family: Menlo, Consolas, "Ubuntu Mono",
+        "Roboto Mono", "DejaVu Sans Mono",
+        monospace'>${messageHtml}</div></body>` + tail;
+    this.webviewEditor.webview.html = output;
+    this.update();
+  }
+
+  private async resolvePythonPath(
+    resource: vscode.Uri,
+    workspacePath: string
+  ): Promise<PythonPathResolutionResult> {
+    const configuredPythonPath = (getOption('vscode-pydata-viewer.pythonPath') as string | undefined) ?? 'default';
+    const usePythonExtensionInterpreter =
+      (getOption('vscode-pydata-viewer.usePythonExtensionInterpreter') as boolean | undefined) ?? true;
+    const pythonExtensionPath = usePythonExtensionInterpreter
+      ? await this.interpreterService.getActiveInterpreterPath(resource)
+      : undefined;
+
+    return resolvePythonPathPriority({
+      configuredPythonPath,
+      workspacePath,
+      usePythonExtensionInterpreter,
+      pythonExtensionPath,
+      fallbackPythonPath: PythonShell.defaultPythonPath,
+    });
   }
 
   public static suffixToType(suffix: string) {

--- a/src/pydataProvider.ts
+++ b/src/pydataProvider.ts
@@ -1,5 +1,7 @@
 import * as vscode from 'vscode';
 import { PyDataPreview } from './pydataPreview';
+import { Resource } from '@vscode/python-extension';
+import { PythonInterpreterService } from './pythonInterpreter';
 
 export class PyDataCustomProvider implements vscode.CustomReadonlyEditorProvider {
   public static readonly viewType = 'pydata.preview';
@@ -8,7 +10,8 @@ export class PyDataCustomProvider implements vscode.CustomReadonlyEditorProvider
   private _activePreview: PyDataPreview | undefined;
 
   constructor(private readonly context: vscode.ExtensionContext,
-    private readonly extensionRoot: vscode.Uri) { }
+    private readonly extensionRoot: vscode.Uri,
+    private readonly interpreterService: PythonInterpreterService) { }
 
   public openCustomDocument(uri: vscode.Uri): vscode.CustomDocument {
     return { uri, dispose: (): void => { } };
@@ -22,7 +25,8 @@ export class PyDataCustomProvider implements vscode.CustomReadonlyEditorProvider
       this.context,
       this.extensionRoot,
       document.uri,
-      webviewEditor
+      webviewEditor,
+      this.interpreterService
     );
     this._previews.add(preview);
     this.setActivePreview(preview);
@@ -52,5 +56,23 @@ export class PyDataCustomProvider implements vscode.CustomReadonlyEditorProvider
     if (this._activePreview) {
       this._activePreview.toggleTruncation();
     }
+  }
+
+  public reloadAllPreviews(resource?: Resource): void {
+    for (const preview of this._previews) {
+      if (resource && !this.isResourceMatch(preview, resource)) {
+        continue;
+      }
+      preview.refreshFromInterpreterChange();
+    }
+  }
+
+  private isResourceMatch(preview: PyDataPreview, resource: Resource): boolean {
+    if (resource instanceof vscode.Uri) {
+      return preview.resourceUri.toString() === resource.toString();
+    }
+
+    const previewFolder = vscode.workspace.getWorkspaceFolder(preview.resourceUri);
+    return previewFolder?.uri.toString() === resource.uri.toString();
   }
 }

--- a/src/pythonInterpreter.ts
+++ b/src/pythonInterpreter.ts
@@ -1,0 +1,243 @@
+import * as vscode from 'vscode';
+import {
+  ActiveEnvironmentPathChangeEvent,
+  EnvironmentPath,
+  PVSC_EXTENSION_ID,
+  PythonExtension,
+  Resource,
+} from '@vscode/python-extension';
+
+export type InterpreterSource = 'python-extension' | 'unknown';
+
+export type InterpreterChange = {
+  resource: Resource | undefined;
+  path: string | undefined;
+  source: InterpreterSource;
+};
+
+/**
+ * Adapter around ms-python.python APIs.
+ *
+ * Goals:
+ * 1) Keep all Python-extension API calls in one place.
+ * 2) Expose a stable method to resolve active interpreter path per resource.
+ * 3) Expose an event for interpreter changes.
+ */
+export class PythonInterpreterService implements vscode.Disposable {
+  private pythonApi: PythonExtension | undefined;
+  private apiLoadPromise: Promise<PythonExtension | undefined> | undefined;
+  private activeEnvironmentListener: vscode.Disposable | undefined;
+  private extensionsChangeListener: vscode.Disposable | undefined;
+  private lastKnownExtensionState: { exists: boolean; isActive: boolean } | undefined;
+
+  private readonly _onDidChangeInterpreter = new vscode.EventEmitter<InterpreterChange>();
+  public readonly onDidChangeInterpreter = this._onDidChangeInterpreter.event;
+
+  public async initialize(): Promise<void> {
+    this.ensureExtensionsChangeListener();
+    this.lastKnownExtensionState = this.getPythonExtensionState();
+    console.log('[PyData Viewer] Initial Python extension state:', this.lastKnownExtensionState);
+    await this.getPythonApi();
+  }
+
+  public async getActiveInterpreterPath(resource?: Resource): Promise<string | undefined> {
+    const api = await this.getPythonApi();
+    if (!api) {
+      return undefined;
+    }
+
+    const environmentPath = api.environments.getActiveEnvironmentPath(resource);
+    return this.resolveExecutablePath(api, environmentPath);
+  }
+
+  public dispose(): void {
+    this.extensionsChangeListener?.dispose();
+    this.activeEnvironmentListener?.dispose();
+    this._onDidChangeInterpreter.dispose();
+  }
+
+  private async getPythonApi(): Promise<PythonExtension | undefined> {
+    if (this.pythonApi) {
+      return this.pythonApi;
+    }
+
+    if (!this.apiLoadPromise) {
+      this.apiLoadPromise = this.activatePythonApi();
+    }
+
+    this.pythonApi = await this.apiLoadPromise;
+
+    // Important: do not permanently cache failed initialization.
+    // If Python extension is enabled later, we must retry loading API.
+    if (!this.pythonApi) {
+      this.apiLoadPromise = undefined;
+    }
+
+    return this.pythonApi;
+  }
+
+  private ensureExtensionsChangeListener(): void {
+    if (this.extensionsChangeListener) {
+      return;
+    }
+
+    this.extensionsChangeListener = vscode.extensions.onDidChange(() => {
+      void this.handleExtensionsChanged();
+    });
+  }
+
+  private getPythonExtensionState(): { exists: boolean; isActive: boolean } {
+    const extension = vscode.extensions.getExtension(PVSC_EXTENSION_ID);
+    return {
+      exists: !!extension,
+      isActive: extension?.isActive ?? false,
+    };
+  }
+
+  private async handleExtensionsChanged(): Promise<void> {
+    const currentState = this.getPythonExtensionState();
+    const previousState = this.lastKnownExtensionState;
+    this.lastKnownExtensionState = currentState;
+
+    console.log('[PyData Viewer] Extension change detected.', {
+      extensionId: PVSC_EXTENSION_ID,
+      previousState,
+      currentState,
+    });
+
+    // Skip unrelated extension changes.
+    if (
+      previousState &&
+      previousState.exists === currentState.exists &&
+      previousState.isActive === currentState.isActive
+    ) {
+      return;
+    }
+
+    // Extension removed/disabled/unloaded.
+    if (!currentState.exists) {
+      console.log('[PyData Viewer] Python extension unavailable. Resetting API cache.');
+      this.resetPythonApiState();
+      return;
+    }
+
+    // Extension is present but inactive now. Reset and wait for next activation.
+    if (!currentState.isActive) {
+      console.log('[PyData Viewer] Python extension is present but inactive. Waiting for activation.');
+      this.resetPythonApiState();
+      return;
+    }
+
+    // Extension became available/active again. Reconnect and notify previews.
+    this.resetPythonApiState();
+    console.log('[PyData Viewer] Python extension became active again. Attempting API recovery...');
+    await this.tryRecoverPythonApiAndNotify();
+  }
+
+  private async tryRecoverPythonApiAndNotify(): Promise<void> {
+    const api = await this.getPythonApi();
+    if (!api) {
+      console.log('[PyData Viewer] API recovery skipped: Python API still unavailable.');
+      return;
+    }
+
+    const path = await this.getActiveInterpreterPath();
+    console.log('[PyData Viewer] API recovered. Broadcasting interpreter refresh event.', {
+      path,
+      source: 'python-extension',
+    });
+    this._onDidChangeInterpreter.fire({
+      resource: undefined,
+      path,
+      source: 'python-extension',
+    });
+  }
+
+  private resetPythonApiState(): void {
+    console.log('[PyData Viewer] Resetting Python API state cache and listeners.');
+    this.pythonApi = undefined;
+    this.apiLoadPromise = undefined;
+    this.activeEnvironmentListener?.dispose();
+    this.activeEnvironmentListener = undefined;
+  }
+
+  private async activatePythonApi(): Promise<PythonExtension | undefined> {
+    const pythonExtension = vscode.extensions.getExtension(PVSC_EXTENSION_ID);
+    if (!pythonExtension) {
+      console.log('[PyData Viewer] Python extension is not installed.');
+      return undefined;
+    }
+
+    try {
+      if (!pythonExtension.isActive) {
+        console.log('[PyData Viewer] Activating Python extension...');
+        await pythonExtension.activate();
+      }
+
+      const api = await PythonExtension.api();
+      console.log('[PyData Viewer] Python extension API activated successfully.');
+      this.ensureEnvironmentListener(api);
+      return api;
+    } catch (error) {
+      console.error('[PyData Viewer] Failed to activate Python extension API:', error);
+      return undefined;
+    }
+  }
+
+  private ensureEnvironmentListener(api: PythonExtension): void {
+    if (this.activeEnvironmentListener) {
+      return;
+    }
+
+    this.activeEnvironmentListener = api.environments.onDidChangeActiveEnvironmentPath((event) => {
+      void this.handleActiveEnvironmentChange(event);
+    });
+  }
+
+  private async handleActiveEnvironmentChange(event: ActiveEnvironmentPathChangeEvent): Promise<void> {
+    const api = await this.getPythonApi();
+
+    let resolvedPath: string | undefined = event.path;
+    if (api) {
+      resolvedPath = await this.resolveExecutablePath(api, event);
+    }
+
+    console.log('[PyData Viewer] Active interpreter changed.', {
+      resource: event.resource,
+      rawPath: event.path,
+      resolvedPath,
+    });
+
+    this._onDidChangeInterpreter.fire({
+      resource: event.resource,
+      path: resolvedPath,
+      source: 'python-extension',
+    });
+  }
+
+  private async resolveExecutablePath(
+    api: PythonExtension,
+    environmentPath: EnvironmentPath | undefined
+  ): Promise<string | undefined> {
+    if (!environmentPath) {
+      return undefined;
+    }
+
+    try {
+      const resolved = await api.environments.resolveEnvironment(environmentPath);
+      const executablePath = resolved?.executable.uri?.fsPath;
+      if (executablePath && executablePath.trim().length > 0) {
+        return executablePath;
+      }
+
+      const fallbackPath = resolved?.path ?? environmentPath.path;
+      if (fallbackPath && fallbackPath.trim().length > 0) {
+        return fallbackPath;
+      }
+    } catch (error) {
+      console.error('[PyData Viewer] Failed to resolve active environment:', error);
+    }
+
+    return undefined;
+  }
+}

--- a/src/pythonPathResolution.ts
+++ b/src/pythonPathResolution.ts
@@ -1,0 +1,47 @@
+export type PythonPathSource = 'manual' | 'python-extension' | 'fallback';
+
+export type PythonPathResolutionResult = {
+  path: string | undefined;
+  source: PythonPathSource;
+  hint: string;
+};
+
+export type PythonPathResolutionInput = {
+  configuredPythonPath: string;
+  workspacePath: string;
+  usePythonExtensionInterpreter: boolean;
+  pythonExtensionPath: string | undefined;
+  fallbackPythonPath: string;
+};
+
+/**
+ * Pure resolver for interpreter source priority:
+ * manual > python-extension > fallback
+ */
+export function resolvePythonPathPriority(
+  input: PythonPathResolutionInput
+): PythonPathResolutionResult {
+  const configured = input.configuredPythonPath ?? 'default';
+
+  if (configured !== 'default') {
+    return {
+      path: configured.replace('${workspaceFolder}', input.workspacePath),
+      source: 'manual',
+      hint: 'Please check setting: vscode-pydata-viewer.pythonPath',
+    };
+  }
+
+  if (input.usePythonExtensionInterpreter && input.pythonExtensionPath) {
+    return {
+      path: input.pythonExtensionPath,
+      source: 'python-extension',
+      hint: 'Interpreter is resolved from ms-python.python active environment.',
+    };
+  }
+
+  return {
+    path: input.fallbackPythonPath,
+    source: 'fallback',
+    hint: 'Fallback to PythonShell default interpreter.',
+  };
+}


### PR DESCRIPTION
## Background

When `pythonPath=default`, the extension currently falls back to `python-shell` default only, and does not follow the interpreter selected via **Python: Select Interpreter** from `ms-python.python`. (see issue #27 )

## What changed

1. Added optional interpreter-follow integration
   - Added `src/pythonInterpreter.ts` to wrap Python extension API access and event subscription.
   - Runtime detection of `ms-python.python` (no hard extension dependency).

2. Added interpreter resolution priority
   - Added pure resolver `src/pythonPathResolution.ts`.
   - Resolution order:
     - `manual`: `vscode-pydata-viewer.pythonPath != "default"`
     - `python-extension`: `pythonPath=default` + `usePythonExtensionInterpreter=true` + active interpreter available
     - `fallback`: `PythonShell.defaultPythonPath`

3. Wired into extension flow
   - `src/extension.ts`: initialize `PythonInterpreterService`, subscribe to interpreter-change events.
   - `src/pydataProvider.ts`: add `reloadAllPreviews(resource?)` for resource/workspace scoped refresh.
   - `src/pydataPreview.ts`: use the new async resolver and refresh on interpreter changes.

4. Concurrency and robustness improvements
   - Added `requestId` guard in `src/pydataPreview.ts` to prevent stale async responses overriding newer results.
   - Path existence check now applies only to explicit paths, avoiding false failures for command names like `python` / `python3`.
   - Added extension recovery flow in `src/pythonInterpreter.ts`: after disabling and re-enabling Python extension, API reconnects and previews refresh without requiring `Reload Window`.
   - Added diagnostic logs for extension state changes, API recovery, and interpreter-change broadcasts.

5. Config and docs updates
   - `package.json`: new setting
     - `vscode-pydata-viewer.usePythonExtensionInterpreter` (default `true`)
   - Updated `pythonPath` description to clarify `default` behavior.
   - Updated `README.md` and `CONFIG_GUIDE.md`.

## Compatibility
- Backward compatible: manual `pythonPath` remains highest priority.
- Extension remains functional without Python extension installed (graceful fallback).

## Validation
- `npm run compile`: passed.
- Manual verification: verified the feature with the debugger of VS Code extensions.
